### PR TITLE
Use system uuid if possible, instead of a custom signature file.

### DIFF
--- a/checkpoint.go
+++ b/checkpoint.go
@@ -12,7 +12,6 @@ import (
 	"golang.org/x/crypto/scrypt"
 	"io"
 	"io/ioutil"
-	"log"
 	mrand "math/rand"
 	"net/http"
 	"net/url"
@@ -120,17 +119,17 @@ func Check(p *CheckParams) (*CheckResponse, error) {
 		p.OS = runtime.GOOS
 	}
 
-	// If we're given a SignatureFile, then attempt to read that.
+	// If we're not given a Signature, then attempt to read one.
 	signature := p.Signature
-	if p.Signature == "" && p.SignatureFile != "" {
+	if p.Signature == "" {
 		var err error
-		signature, err = getSystemUUID()
-		if err != nil {
-			log.Printf("Error: %v", err)
+		if p.SignatureFile == "" {
+			signature, err = getSystemUUID()
+		} else {
 			signature, err = checkSignature(p.SignatureFile)
-			if err != nil {
-				return nil, err
-			}
+		}
+		if err != nil {
+			return nil, err
 		}
 	}
 

--- a/checkpoint.go
+++ b/checkpoint.go
@@ -3,12 +3,16 @@
 package checkpoint
 
 import (
+	"bytes"
 	"crypto/rand"
+	"encoding/base64"
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/crypto/scrypt"
 	"io"
 	"io/ioutil"
+	"log"
 	mrand "math/rand"
 	"net/http"
 	"net/url"
@@ -120,9 +124,13 @@ func Check(p *CheckParams) (*CheckResponse, error) {
 	signature := p.Signature
 	if p.Signature == "" && p.SignatureFile != "" {
 		var err error
-		signature, err = checkSignature(p.SignatureFile)
+		signature, err = getSystemUUID()
 		if err != nil {
-			return nil, err
+			log.Printf("Error: %v", err)
+			signature, err = checkSignature(p.SignatureFile)
+			if err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -282,6 +290,31 @@ func checkResult(r io.Reader) (*CheckResponse, error) {
 	}
 
 	return &result, nil
+}
+
+// getSystemUUID returns the base64 encoded, scrypt hashed contents of
+// /sys/class/dmi/id/product_uuid (with some salt)
+func getSystemUUID() (string, error) {
+	uuid, err := ioutil.ReadFile("/sys/class/dmi/id/product_uuid")
+	if err != nil {
+		return "", err
+	}
+	if len(uuid) <= 0 {
+		return "", fmt.Errorf("Empty system uuid")
+	}
+	hash, err := scrypt.Key(uuid, uuid, 16384, 8, 1, 32)
+	if err != nil {
+		return "", err
+	}
+	output := bytes.Buffer{}
+	encoder := base64.NewEncoder(base64.StdEncoding, &output)
+	if _, err := encoder.Write(hash); err != nil {
+		return "", err
+	}
+	if err := encoder.Close(); err != nil {
+		return "", err
+	}
+	return output.String(), nil
 }
 
 func checkSignature(path string) (string, error) {


### PR DESCRIPTION
We use an scrypt hash of /sys/class/dmi/id/product_uuid, to make it expensive to try and brute force the hash.
