### PR TITLE
update description to refer to Weaveworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,27 @@
 # Go Checkpoint Client
 
-[Checkpoint](http://checkpoint.hashicorp.com) is an internal service at
-Hashicorp that we use to check version information, broadcoast security
-bulletins, etc.
+Checkpoint is an internal service at
+[Weaveworks](https://www.weave.works/) to check version information,
+broadcast security bulletins, etc. This repository contains the client
+code for accessing that service. It is a fork of
+[Hashicorp's Go Checkpoint Client](https://github.com/hashicorp/go-checkpoint)
+and is embedded in several
+[Weaveworks open source projects](https://github.com/weaveworks/) and
+proprietary software.
 
-We understand that software making remote calls over the internet
-for any reason can be undesirable. Because of this, Checkpoint can be
-disabled in all of our software that includes it. You can view the source
-of this client to see that we're not sending any private information.
+We understand that software making remote calls over the internet for
+any reason can be undesirable. Because of this, Checkpoint can be
+disabled in all of Weavework's software that includes it. You can view
+the source of this client to see that it is not sending any private
+information.
 
-Each Hashicorp application has it's specific configuration option
-to disable chekpoint calls, but the `CHECKPOINT_DISABLE` makes
-the underlying checkpoint component itself disabled. For example
-in the case of packer:
+To disable checkpoint calls, set the `CHECKPOINT_DISABLE` environment
+variable, e.g.
+
 ```
-CHECKPOINT_DISABLE=1 packer build 
+export CHECKPOINT_DISABLE=1
 ```
 
-**Note:** This repository is probably useless outside of internal HashiCorp
-use. It is open source for disclosure and because our open source projects
-must be able to link to it.
+**Note:** This repository is probably useless outside of internal
+Weaveworks use. It is open source for disclosure and because
+Weaveworks open source projects must be able to link to it.


### PR DESCRIPTION
...to avoid readers mistakenly thinking that Weaveworks software sends information to Hashicorp.
